### PR TITLE
Feature vscode user friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ target/
 
 # DotEnv configuration
 .env
+.venv
 
 # conda
 .conda

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ dask-worker-space/
 *.csv
 *.gz*
 
+# Local 
+temp/
+
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
Add temp folder (for personal notes, pieces of code, ToDos...) and .venv file on the .gitignore file in order to use python virtual environment inside vscode.